### PR TITLE
Adds `dispatch` as 3rd arg to `effectImplementation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ const Fetcher = () => {
 };
 ```
 
+Each method of the `effectMap` receives three arguments: the reducer's `state`, the `event`, and reducer's `dispatch`. This enables dispatching within effects in the `effectMap` if it is written outside of the scope of your component. If your effects require access to variables and functions in the scope of your component, write your `effectMap` there.
+
 ## API
 
 ### `useEffectReducer` hook

--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ const countReducer = (state, event, exec) => {
 const App = () => {
   const [state, dispatch] = useEffectReducer(countReducer, { count: 0 });
 
-  return <div>
-    <output>Count: {state.count}</output>
-    <button onClick={() => dispatch('INC')}>
-      Increment
-    </button>
-  </div>;
+  return (
+    <div>
+      <output>Count: {state.count}</output>
+      <button onClick={() => dispatch('INC')}>Increment</button>
+    </div>
+  );
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     }
   },
   "prettier": {
+    "arrowParens": "avoid",
     "printWidth": 80,
     "semi": true,
     "singleQuote": true,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -86,7 +86,7 @@ export function useEffectReducer<
       return [state, effects.slice(event.count)];
     }
 
-    const nextState = effectReducer(state, event, (effect) => {
+    const nextState = effectReducer(state, event, effect => {
       nextEffects.push(effect);
     });
 
@@ -104,7 +104,7 @@ export function useEffectReducer<
   useEffect(() => {
     if (stateEffectTuples.length) {
       stateEffectTuples.forEach(([stateForEffect, effects]) => {
-        effects?.forEach((effect) => {
+        effects?.forEach(effect => {
           let effectImplementation: EffectFunction<TState, TEvent> | undefined;
           if (typeof effect === 'object' && 'type' in effect) {
             if (effectsMap && effectsMap[effect.type]) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,28 +1,34 @@
 import { useReducer, useEffect } from 'react';
 
-export type EffectFunction<TState> = (
+export type EffectFunction<TState, TEvent> = (
   state: TState,
-  effect: EffectObject<TState>
+  effect: EffectObject<TState, TEvent>,
+  dispatch: React.Dispatch<TEvent>
 ) => void;
 
-export interface EffectObject<TState> {
+export interface EffectObject<TState, TEvent> {
   [key: string]: any;
   type: string;
-  exec?: EffectFunction<TState>;
+  exec?: EffectFunction<TState, TEvent>;
 }
 
-export type Effect<TState, TEffect extends EffectObject<TState>> =
-  | TEffect
-  | EffectFunction<TState>;
-
-type StateEffectTuple<TState, TEffect extends EffectObject<TState>> =
-  | [TState, Effect<TState, TEffect>[] | undefined]
-  | [TState];
-
-type AggregatedEffectsState<TState, TEffect extends EffectObject<TState>> = [
+export type Effect<
   TState,
-  StateEffectTuple<TState, TEffect>[]
-];
+  TEvent,
+  TEffect extends EffectObject<TState, TEvent>
+> = TEffect | EffectFunction<TState, TEvent>;
+
+type StateEffectTuple<
+  TState,
+  TEvent,
+  TEffect extends EffectObject<TState, TEvent>
+> = [TState, Effect<TState, TEvent, TEffect>[] | undefined] | [TState];
+
+type AggregatedEffectsState<
+  TState,
+  TEvent,
+  TEffect extends EffectObject<TState, TEvent>
+> = [TState, StateEffectTuple<TState, TEvent, TEffect>[]];
 
 export interface EventObject {
   type: string;
@@ -32,11 +38,11 @@ export interface EventObject {
 export type EffectReducer<
   TState,
   TEvent extends EventObject,
-  TEffect extends EffectObject<TState> = EffectObject<TState>
+  TEffect extends EffectObject<TState, TEvent> = EffectObject<TState, TEvent>
 > = (
   state: TState,
   event: TEvent,
-  exec: (effect: TEffect | EffectFunction<TState>) => void
+  exec: (effect: TEffect | EffectFunction<TState, TEvent>) => void
 ) => TState;
 
 const flushEffectsSymbol = Symbol();
@@ -47,40 +53,40 @@ interface FlushEvent {
   count: number;
 }
 
-export function toEffect<TState>(
-  exec: EffectFunction<TState>
-): Effect<TState, any> {
+export function toEffect<TState, TEvent>(
+  exec: EffectFunction<TState, TEvent>
+): Effect<TState, TEvent, any> {
   return {
     type: exec.name,
     exec,
   };
 }
 
-interface EffectsMap<TState> {
-  [key: string]: EffectFunction<TState>;
+interface EffectsMap<TState, TEvent> {
+  [key: string]: EffectFunction<TState, TEvent>;
 }
 
 export function useEffectReducer<
   TState,
   TEvent extends EventObject,
-  TEffect extends EffectObject<TState> = EffectObject<TState>
+  TEffect extends EffectObject<TState, TEvent> = EffectObject<TState, TEvent>
 >(
   effectReducer: EffectReducer<TState, TEvent, TEffect>,
   initialState: TState,
-  effectsMap?: EffectsMap<TState>
+  effectsMap?: EffectsMap<TState, TEvent>
 ): [TState, React.Dispatch<TEvent>] {
   const wrappedReducer = (
-    [state, effects]: AggregatedEffectsState<TState, TEffect>,
+    [state, effects]: AggregatedEffectsState<TState, TEvent, TEffect>,
     event: TEvent | FlushEvent
-  ): AggregatedEffectsState<TState, TEffect> => {
-    const nextEffects: Array<Effect<TState, TEffect>> = [];
+  ): AggregatedEffectsState<TState, TEvent, TEffect> => {
+    const nextEffects: Array<Effect<TState, TEvent, TEffect>> = [];
 
     if (event.type === flushEffectsSymbol) {
       // Record that effects have already been executed
       return [state, effects.slice(event.count)];
     }
 
-    const nextState = effectReducer(state, event, effect => {
+    const nextState = effectReducer(state, event, (effect) => {
       nextEffects.push(effect);
     });
 
@@ -98,8 +104,8 @@ export function useEffectReducer<
   useEffect(() => {
     if (stateEffectTuples.length) {
       stateEffectTuples.forEach(([stateForEffect, effects]) => {
-        effects?.forEach(effect => {
-          let effectImplementation: EffectFunction<TState> | undefined;
+        effects?.forEach((effect) => {
+          let effectImplementation: EffectFunction<TState, TEvent> | undefined;
           if (typeof effect === 'object' && 'type' in effect) {
             if (effectsMap && effectsMap[effect.type]) {
               effectImplementation = effectsMap[effect.type] || effect.exec;
@@ -113,7 +119,8 @@ export function useEffectReducer<
           if (effectImplementation) {
             effectImplementation(
               stateForEffect,
-              typeof effect === 'object' ? effect : { type: effect.name }
+              typeof effect === 'object' ? effect : { type: effect.name },
+              dispatch
             );
           }
         });


### PR DESCRIPTION
Fixes #2 

## Description

This PR adds `dispatch` as the third argument to the `effectImplementation` function.

I also added `avoidParens` to the Prettier config as it was conflicting with an eslint rule. I can split that out if required.

## Tasks

- [x] Add a test using `dispatch`
- [x] Update docs