### PR TITLE
Add support for cleaning up effects.

### DIFF
--- a/.changeset/tiny-donkeys-fly.md
+++ b/.changeset/tiny-donkeys-fly.md
@@ -1,0 +1,13 @@
+---
+'use-effect-reducer': minor
+---
+
+Effects can now be managed and stopped via "effect entities", which are special objects returned from `exec(effect)`:
+
+```js
+const someEntity = exec(someEffect);
+```
+
+Having a reference to the effect entity allows you to stop the effect by calling `exec.stop(someEntity)`, and even replace it with a new effect entity by calling `exec.replace(someEntity, effect)`.
+
+All running effects in a component are now properly disposed when the component unmounts.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ An "effect reducer" takes 3 arguments:
 
 1. `state` - the current state
 2. `event` - the event that was dispatched to the reducer
-3. `exec` - a function that captures effects to be executed.
+3. `exec` - a function that captures effects to be executed and returns an [effect entity](#effect-entities) that allows you to control the effect
 
 ```js
 import { useEffectReducer } from 'use-effect-reducer';
@@ -162,6 +162,160 @@ const Fetcher = () => {
 };
 ```
 
+## Effect Implementations
+
+An effect implementation is a function that takes 3 arguments:
+
+1. The `state` at the time the effect was executed with `exec(effect)`
+2. The `event` object that triggered the effect
+3. The effect reducer's `dispatch` function to dispatch events back to it. This enables dispatching within effects in the `effectMap` if it is written outside of the scope of your component. If your effects require access to variables and functions in the scope of your component, write your `effectMap` there.
+
+The effect implementation should return a disposal function that cleans up the effect:
+
+```js
+// Effect defined inline
+exec(() => {
+  const id = setTimeout(() => {
+    // do some delayed side-effect
+  }, 1000);
+
+  // disposal function
+  return () => {
+    clearTimeout(id);
+  };
+});
+```
+
+```js
+// Parameterized effect implementation
+// (in the effect reducer)
+exec({ type: 'doDelayedEffect' });
+
+// ...
+
+// (in the component)
+const [state, dispatch] = useEffectReducer(someReducer, initialState, {
+  doDelayedEffect: () => {
+    const id = setTimeout(() => {
+      // do some delayed side-effect
+    }, 1000);
+
+    // disposal function
+    return () => {
+      clearTimeout(id);
+    };
+  },
+});
+```
+
+## Effect Entities
+
+The `exec(effect)` function returns an **effect entity**, which is a special object that represents the running effect. These objects can be stored directly in the reducer's state:
+
+```js
+const someReducer = (state, event, exec) => {
+  // ...
+
+  return {
+    ...state,
+    // state.someEffect is now an effect entity
+    someEffect: exec(() => {
+      /* ... */
+    }),
+  };
+};
+```
+
+The advantage of having a reference to the effect (via the returned effect `entity`) is that you can explicitly [stop those effects](#effect-cleanup):
+
+```js
+const someReducer = (state, event, exec) => {
+  // ...
+
+  // Stop an effect entity
+  exec.stop(state.someEffect);
+
+  return {
+    ...state,
+    // state.someEffect is no longer needed
+    someEffect: undefined,
+  };
+};
+```
+
+## Effect Cleanup
+
+Instead of implicitly relying on arbitrary values in a dependency array changing to stop an effect (as you would with `useEffect`), effects can be explicitly stopped using `exec.stop(entity)`, where `entity` is the effect entity returned from initially calling `exec(effect)`:
+
+```js
+const timerReducer = (state, event, exec) => {
+  if (event.type === 'START') {
+    return {
+      ...state,
+      timer: exec(() => {
+        const id = setTimeout(() => {
+          // Do some delayed effect
+        }, 1000);
+
+        // Disposal function - will be called when
+        // effect entity is stopped
+        return () => {
+          clearTimeout(id);
+        };
+      }),
+    };
+  } else if (event.type === 'STOP') {
+    // Stop the effect entity
+    exec.stop(state.timer);
+
+    return state;
+  }
+
+  return state;
+};
+```
+
+All running effect entities will automatically be stopped when the component unmounts.
+
+## Replacing Effects
+
+If you want to replace an effect with another (likely similar) effect, instead of calling `exec.stop(entity)` and calling `exec(effect)` to manually replace an effect, you can call `exec.replace(entity, effect)` as a shorthand:
+
+```js
+const doSomeDelay = () => {
+  const id = setTimeout(() => {
+    // do some delayed effect
+  }, delay);
+
+  return () => {
+    clearTimeout(id);
+  };
+};
+
+const timerReducer = (state, event, exec) => {
+  if (event.type === 'START') {
+    return {
+      ...state,
+      timer: exec(() => doSomeDelay()),
+    };
+  } else if (event.type === 'LAP') {
+    // Replace the currently running effect represented by `state.timer`
+    // with a new effect
+    return {
+      ...state,
+      timer: exec.replace(state.timer, () => doSomeDelay()),
+    };
+  } else if (event.type === 'STOP') {
+    // Stop the effect entity
+    exec.stop(state.timer);
+
+    return state;
+  }
+
+  return state;
+};
+```
+
 ## String Events
 
 The events handled by the effect reducers are intended to be event objects with a `type` property; e.g., `{ type: 'FETCH', other: 'data' }`. For events without payload, you can dispatch the event type alone, which will be converted to an event object inside the effect reducer:
@@ -171,14 +325,6 @@ The events handled by the effect reducers are intended to be event objects with 
 // and is the same as `dispatch({ type: 'INC' })`
 dispatch('INC');
 ```
-
-## Effect Implementations
-
-An effect implementation is a function that takes 3 arguments:
-
-1. The `state` at the time the effect was executed with `exec(effect)`
-2. The `event` object that triggered the effect
-3. The effect reducer's `dispatch` function to dispatch events back to it. This enables dispatching within effects in the `effectMap` if it is written outside of the scope of your component. If your effects require access to variables and functions in the scope of your component, write your `effectMap` there.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,20 @@ If you know how to [`useReducer`](https://reactjs.org/docs/hooks-reference.html#
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Named Effects](#named-effects)
 - [Effect Implementations](#effect-implementations)
+- [Effect Entities](#effect-entities)
+- [Effect Cleanup](#effect-cleanup)
+- [Replacing Effects](#replacing-effects)
+- [String Events](#string-events)
 - [API](#api)
   - [`useEffectReducer` hook](#useeffectreducer-hook)
+  - [`exec(effect)`](#execeffect)
+  - [`exec.stop(entity)`](#execstopentity)
+- [`exec.replace(entity, effect)`](#execreplaceentity-effect)
 - [TypeScript](#typescript)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -353,6 +361,45 @@ const SomeComponent = () => {
   // ...
 };
 ```
+
+### `exec(effect)`
+
+Used in an effect reducer, `exec(effect)` queues the `effect` for execution and returns an [effect entity](#effect-entities).
+
+The `effect` can either be an effect object:
+
+```js
+// ...
+const entity = exec({
+  type: 'alert',
+  message: 'hello',
+});
+```
+
+Or it can be an inline effect implementation:
+
+```js
+// ...
+const entity = exec(() => {
+  alert('hello');
+});
+```
+
+### `exec.stop(entity)`
+
+Used in an effect reducer, `exec.stop(entity)` stops the effect represented by the `entity`. Returns `void`.
+
+```js
+// Queues the effect entity for disposal
+exec.stop(someEntity);
+```
+
+## `exec.replace(entity, effect)`
+
+Used in an effect reducer, `exec.replace(entity, effect)` does two things:
+
+1. Queues the `entity` for disposal (same as calling `exec.stop(entity)`)
+2. Returns a new [effect entity](#effect-entities) that represents the `effect` that replaces the previous `entity`.
 
 ## TypeScript
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,12 @@
 import { useReducer, useEffect, useCallback } from 'react';
 
+type CleanupFunction = () => void;
+
 export type EffectFunction<TState, TEvent> = (
   state: TState,
   effect: EffectObject<TState, TEvent>,
   dispatch: React.Dispatch<TEvent>
-) => void;
+) => CleanupFunction | void;
 
 export interface EffectObject<TState, TEvent> {
   [key: string]: any;
@@ -18,21 +20,60 @@ export type Effect<
   TEffect extends EffectObject<TState, TEvent>
 > = TEffect | EffectFunction<TState, TEvent>;
 
-type StateEffectTuple<
+type StateEffectTuple<TState, TEvent extends EventObject> = [
   TState,
-  TEvent,
-  TEffect extends EffectObject<TState, TEvent>
-> = [TState, TEffect[] | undefined] | [TState];
+  EffectEntity<TState, TEvent>[]
+];
 
-type AggregatedEffectsState<
+type AggregatedEffectsState<TState, TEvent extends EventObject> = [
   TState,
-  TEvent,
-  TEffect extends EffectObject<TState, TEvent>
-> = [TState, StateEffectTuple<TState, TEvent, TEffect>[]];
+  StateEffectTuple<TState, TEvent>[],
+  EffectEntity<TState, TEvent>[]
+];
 
 export interface EventObject {
   type: string;
   [key: string]: any;
+}
+
+export interface EffectEntity<TState, TEvent extends EventObject> {
+  type: string;
+  start: (state: TState, dispatch: React.Dispatch<TEvent>) => void;
+  stop: () => void;
+}
+
+function createEffectEntity<
+  TState,
+  TEvent extends EventObject,
+  TEffect extends EffectObject<TState, TEvent>
+>(effect: TEffect): EffectEntity<TState, TEvent> {
+  let effectCleanup: CleanupFunction | void;
+
+  return {
+    type: effect.type,
+    start: (state, dispatch) => {
+      if (effect.exec) {
+        effectCleanup = effect.exec(state, effect, dispatch);
+      }
+    },
+    stop: () => {
+      if (effectCleanup && typeof effectCleanup === 'function') {
+        effectCleanup();
+      }
+    },
+  };
+}
+
+export interface EffectReducerExec<
+  TState,
+  TEvent extends EventObject,
+  TEffect extends EffectObject<TState, TEvent>
+> {
+  (effect: TEffect | EffectFunction<TState, TEvent>): EffectEntity<
+    TState,
+    TEvent
+  >;
+  stop: (entity: EffectEntity<TState, TEvent>) => void;
 }
 
 export type EffectReducer<
@@ -42,7 +83,7 @@ export type EffectReducer<
 > = (
   state: TState,
   event: TEvent,
-  exec: (effect: TEffect | EffectFunction<TState, TEvent>) => void
+  exec: EffectReducerExec<TState, TEvent, TEffect>
 ) => TState;
 
 const flushEffectsSymbol = Symbol();
@@ -81,16 +122,16 @@ const toEffectObject = <
   TEvent extends EventObject,
   TEffect extends EffectObject<TState, TEvent>
 >(
-  effect: TEffect | EffectFunction<TState, TEvent>
+  effect: TEffect | EffectFunction<TState, TEvent>,
+  effectsMap?: EffectsMap<TState, TEvent>
 ): TEffect => {
-  if (typeof effect === 'function') {
-    return {
-      type: effect.name,
-      exec: effect,
-    } as TEffect;
-  }
+  const type = typeof effect === 'function' ? effect.name : effect.type;
+  const customExec = effectsMap ? effectsMap[type] : undefined;
+  const exec =
+    customExec || (typeof effect === 'function' ? effect : effect.exec);
+  const other = typeof effect === 'function' ? {} : effect;
 
-  return effect;
+  return { ...other, type, exec } as TEffect;
 };
 
 export function useEffectReducer<
@@ -103,56 +144,83 @@ export function useEffectReducer<
   effectsMap?: EffectsMap<TState, TEvent>
 ): [TState, React.Dispatch<TEvent | TEvent['type']>] {
   const wrappedReducer = (
-    [state, effects]: AggregatedEffectsState<TState, TEvent, TEffect>,
+    [state, stateEffectTuples, entitiesToStop]: AggregatedEffectsState<
+      TState,
+      TEvent
+    >,
     event: TEvent | FlushEvent
-  ): AggregatedEffectsState<TState, TEvent, TEffect> => {
-    const nextEffects: Array<TEffect> = [];
+  ): AggregatedEffectsState<TState, TEvent> => {
+    const nextEffectEntities: Array<EffectEntity<TState, TEvent>> = [];
+    const nextEntitiesToStop: Array<EffectEntity<TState, TEvent>> = [];
 
     if (event.type === flushEffectsSymbol) {
       // Record that effects have already been executed
-      return [state, effects.slice(event.count)];
+      return [state, stateEffectTuples.slice(event.count), nextEntitiesToStop];
     }
 
-    const nextState = effectReducer(state, event, effect => {
-      nextEffects.push(toEffectObject(effect));
-    });
+    const exec = (effect: TEffect) => {
+      const effectObject = toEffectObject(effect, effectsMap);
+      const effectEntity = createEffectEntity<TState, TEvent, TEffect>(
+        effectObject
+      );
+      nextEffectEntities.push(effectEntity);
+
+      return effectEntity;
+    };
+
+    exec.stop = (entity: EffectEntity<TState, TEvent>) => {
+      nextEntitiesToStop.push(entity);
+    };
+
+    const nextState = effectReducer(
+      state,
+      event,
+      exec as EffectReducerExec<TState, TEvent, TEffect>
+    );
 
     return [
       nextState,
-      nextEffects.length ? [...effects, [nextState, nextEffects]] : effects,
+      nextEffectEntities.length
+        ? [...stateEffectTuples, [nextState, nextEffectEntities]]
+        : stateEffectTuples,
+      entitiesToStop.length
+        ? [...entitiesToStop, ...nextEntitiesToStop]
+        : nextEntitiesToStop,
     ];
   };
 
-  const [[state, stateEffectTuples], dispatch] = useReducer(wrappedReducer, [
-    initialState,
-    [],
-  ]);
+  const [
+    [state, effectStateEntityTuples, entitiesToStop],
+    dispatch,
+  ] = useReducer(wrappedReducer, [initialState, [], []]);
 
   const wrappedDispatch = useCallback((event: TEvent | TEvent['type']) => {
     dispatch(toEventObject(event));
   }, []);
 
   useEffect(() => {
-    if (stateEffectTuples.length) {
-      stateEffectTuples.forEach(([stateForEffect, effects]) => {
-        effects?.forEach(effect => {
-          let effectImplementation: EffectFunction<TState, TEvent> | undefined;
+    // perform cleanup first
+    if (entitiesToStop.length) {
+      entitiesToStop.forEach(entity => {
+        entity.stop();
+      });
+    }
+  }, [entitiesToStop]);
 
-          if (effectsMap && effectsMap[effect.type]) {
-            effectImplementation = effectsMap[effect.type] || effect.exec;
-          } else {
-            effectImplementation = effect.exec;
-          }
-
-          if (effectImplementation) {
-            effectImplementation(stateForEffect, effect, dispatch);
-          }
+  useEffect(() => {
+    if (effectStateEntityTuples.length) {
+      effectStateEntityTuples.forEach(([effectState, effectEntities]) => {
+        effectEntities.forEach(effectEntity => {
+          effectEntity.start(effectState, dispatch);
         });
       });
 
-      dispatch({ type: flushEffectsSymbol, count: stateEffectTuples.length });
+      dispatch({
+        type: flushEffectsSymbol,
+        count: effectStateEntityTuples.length,
+      });
     }
-  }, [stateEffectTuples]);
+  }, [effectStateEntityTuples]);
 
   return [state, wrappedDispatch];
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -86,6 +86,10 @@ export interface EffectReducerExec<
     TEvent
   >;
   stop: (entity: EffectEntity<TState, TEvent>) => void;
+  replace: (
+    entity: EffectEntity<TState, TEvent> | undefined,
+    effect: TEffect | EffectFunction<TState, TEvent>
+  ) => EffectEntity<TState, TEvent>;
 }
 
 export type EffectReducer<
@@ -171,7 +175,7 @@ export function useEffectReducer<
       return [state, stateEffectTuples.slice(event.count), nextEntitiesToStop];
     }
 
-    const exec = (effect: TEffect) => {
+    const exec = (effect: TEffect | EffectFunction<TState, TEvent>) => {
       const effectObject = toEffectObject(effect, effectsMap);
       const effectEntity = createEffectEntity<TState, TEvent, TEffect>(
         effectObject
@@ -183,6 +187,16 @@ export function useEffectReducer<
 
     exec.stop = (entity: EffectEntity<TState, TEvent>) => {
       nextEntitiesToStop.push(entity);
+    };
+
+    exec.replace = (
+      entity: EffectEntity<TState, TEvent>,
+      effect: TEffect | EffectFunction<TState, TEvent>
+    ) => {
+      if (entity) {
+        nextEntitiesToStop.push(entity);
+      }
+      return exec(effect);
     };
 
     const nextState = effectReducer(


### PR DESCRIPTION
This PR adds support for cleaning up effects by introducing "effect entities", which are objects that are returned from `exec(...)` and hold the current state of an effect:

- `EntityStatus.Idle` if the effect hasn't been executed yet
- `EntityStatus.Started` if the effect has been executed
- `EntityStatus.Stopped` if the effect has been disposed

An effect's disposal function can now be returned from the effect implementation, just as in `useEffect`:

```js
// ...

exec(() => {
  const sub = something.subscribe();

  return () => { sub.unsubscribe(); }
});

// ...
```

The difference between how effects are disposed in React and how they are disposed in `useEffectReducer` is that the developer has full control over the "lifecycle" of the effect, by maintaining a reference to that effect entity:

- `exec(effect)` queues the effect for starting (in `useEffect()`) and returns an effect entity
- `exec.stop(entity)` queues the effect represented by the `entity` for disposal

```js
// In the effect reducer:

// ...
if (event.type === 'START') {
  return { 
    ...state,
    sub: exec(() => {/* ... */}
  }
}

if (event.type === 'STOP') {
  // queues the effect for disposal
  exec.stop(state.sub);

  return state;
}
// ...
```

Additionally, all running effects will be automatically disposed when the component is unmounted.


Closes #1 
