### PR TITLE
A little PR to discuss the EffectMap Typing

### DIFF
--- a/test/useEffectReducer.test.tsx
+++ b/test/useEffectReducer.test.tsx
@@ -45,10 +45,15 @@ describe('useEffectReducer', () => {
       user: string;
     };
 
+    type CrazeEffect = {
+      type: 'goCrazy';
+      id: number;
+    };
+
     const fetchEffectReducer: EffectReducer<
       FetchState,
       FetchEvent,
-      FetchEffect
+      FetchEffect | CrazeEffect
     > = (state, event, exec) => {
       switch (event.type) {
         case 'FETCH':
@@ -72,7 +77,7 @@ describe('useEffectReducer', () => {
         fetchEffectReducer,
         { status: 'idle', user: undefined },
         {
-          fetchFromAPI(_, effect) {
+          fetchFromAPI(_, effect: FetchEffect) {
             setTimeout(() => {
               dispatch({
                 type: 'RESOLVE',
@@ -80,6 +85,7 @@ describe('useEffectReducer', () => {
               });
             }, 100);
           },
+          goCrazy(_, fx: CrazeEffect) {},
         }
       );
 

--- a/test/useEffectReducer.test.tsx
+++ b/test/useEffectReducer.test.tsx
@@ -16,10 +16,6 @@ describe('useEffectReducer', () => {
   afterEach(cleanup);
 
   it('basic example', async () => {
-    interface User {
-      name: string;
-    }
-
     type FetchState =
       | {
           status: 'idle';
@@ -27,11 +23,11 @@ describe('useEffectReducer', () => {
         }
       | {
           status: 'fetching';
-          user: User | undefined;
+          user: string | undefined;
         }
       | {
           status: 'fulfilled';
-          user: User;
+          user: string;
         };
 
     type FetchEvent =
@@ -41,7 +37,7 @@ describe('useEffectReducer', () => {
         }
       | {
           type: 'RESOLVE';
-          data: User;
+          data: string;
         };
 
     type FetchEffect = {
@@ -111,10 +107,6 @@ describe('useEffectReducer', () => {
   });
 
   it('third argument dispatch', async () => {
-    interface User {
-      name: string;
-    }
-
     type FetchState =
       | {
           status: 'idle';
@@ -122,11 +114,11 @@ describe('useEffectReducer', () => {
         }
       | {
           status: 'fetching';
-          user: User | undefined;
+          user: string | undefined;
         }
       | {
           status: 'fulfilled';
-          user: User;
+          user: string;
         };
 
     type FetchEvent =
@@ -136,7 +128,7 @@ describe('useEffectReducer', () => {
         }
       | {
           type: 'RESOLVE';
-          data: User;
+          data: string;
         };
 
     type FetchEffect = {


### PR DESCRIPTION
Hello David,
I hope this Pull Request finds you well.
I wrote you this on twitter...
https://twitter.com/fquednau/status/1258777677277904898

While the typings in the exec function passed to the fxReducer can be done nicely, I didn't seem to get type information about the effects object passed in. Also, when writing the effects map passed to the reducer, I didn't get any guidance as to what I had to write there. This needs to be discovered implicitly via docs that the type used for the effects object has to match the key of the effects map.

This PR shows
1) That the EffectsFunction can be typed such that we can get access to typed effect objects
2) That the type of the EffectsMap can be derived from existing Effect Objects.

I have added some comments here & there. This is not meant to be merged just like that, but I think that this would improve the typing situation...

## PS
I introduced these helper types in our code to type out the effect objects:

```typescript
import { EffectObject } from "use-effect-reducer";

export type EffectObjects<
  S,
  E,
  FX extends { [type: string]: Omit<EffectObject<S, E>, "type"> },
  Keys extends keyof FX = keyof FX
> = {
  [K in Keys]: FX[K] & { type: K };
};

export type EffectObjectTypes<
  FX extends { [type: string]: any }, 
  Keys extends keyof FX = keyof FX> = FX[Keys];
```

Then you use that like that:

```typescript
type WelcomeEffectObjects = EffectObjects<
  WelcomeState,
  WelcomeEvent,
  {
    changeLanguage: {
      interfaceLanguage: Nullable<LanguageCode>;
      contentLanguage: Nullable<LanguageCode>;
    };
    finalize: {};
  }
>;

type Exec = EffectReducerExec<
  WelcomeState, 
  WelcomeEvent, 
  EffectObjectTypes<WelcomeEffectObjects>>;
```