### PR TITLE
Initial Effects

### DIFF
--- a/.changeset/three-chefs-play.md
+++ b/.changeset/three-chefs-play.md
@@ -1,0 +1,38 @@
+---
+'use-effect-reducer': minor
+---
+
+Added support for initial effects, via the 2nd argument to `useEffectReducer`, which can either be a static `initialState` or a function that takes in `exec` and returns an initial state as well as executing initial effects:
+
+```js
+const fetchReducer = (state, event) => {
+  if (event.type === 'RESOLVE') {
+    return {
+      ...state,
+      data: event.data,
+    };
+  }
+
+  return state;
+};
+
+const getInitialState = exec => {
+  exec({ type: 'fetchData', someQuery: '*' });
+
+  return { data: null };
+};
+
+// (in the component)
+const [state, dispatch] = useEffectReducer(fetchReducer, getInitialState, {
+  fetchData(_, { someQuery }) {
+    fetch(`/some/api?${someQuery}`)
+      .then(res => res.json())
+      .then(data => {
+        dispatch({
+          type: 'RESOLVE',
+          data,
+        });
+      });
+  },
+});
+```


### PR DESCRIPTION
This PR adds support for initial effects:

cc. @flq as this also addresses effect map typing per #9 

```js
const fetchReducer = (state, event) => {
  if (event.type === 'RESOLVE') {
    return {
      ...state,
      data: event.data,
    };
  }
  return state;
};
const getInitialState = exec => {
  exec({ type: 'fetchData', someQuery: '*' });
  return { data: null };
};
// (in the component)
const [state, dispatch] = useEffectReducer(fetchReducer, getInitialState, {
  fetchData(_, { someQuery }) {
    fetch(`/some/api?${someQuery}`)
      .then(res => res.json())
      .then(data => {
        dispatch({
          type: 'RESOLVE',
          data,
        });
      });
  },
});
```