### PR TITLE
fix syntax error in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const someEffectReducer = (state, event, exec) => {
   // ...
 
   return state;
-});
+};
 ```
 
 [Use it:](#quick-start)


### PR DESCRIPTION
Spotted this unnecessary bracket in the example.

Thanks a lot for making `useEffectReducer`, I followed a similar pattern on one of my projects and it reduced the complexity immensely!