### PR TITLE
Add support for `useLayoutEffect` via `exec.layout` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ If you know how to [`useReducer`](https://reactjs.org/docs/hooks-reference.html#
 
 
 - [Installation](#installation)
+- [Isn't this unsafe?](#isnt-this-unsafe)
 - [Quick Start](#quick-start)
 - [Named Effects](#named-effects)
 - [Effect Implementations](#effect-implementations)


### PR DESCRIPTION
This PR adds an API for calling certain effects with `useLayoutEffect`. This should probably be used very carefully and rarely, but in certain cases it is useful.

API should be identical to calling `exec` directly.

I didn't add documentation yet but am happy to contribute there as well in a follow-up unless someone beats me to it.

Should be pretty straight forward, though the types are getting a bit verbose so let me know if you have any questions!