### PR TITLE
Fix effect cleanup

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -191,12 +191,21 @@ export function useEffectReducer<
     >,
     event: TEvent | FlushEvent
   ): AggregatedEffectsState<TState, TEvent> => {
+    // Remove stopped entities if any, but otherwise keep them around
+    // if they haven't been stopped yet since this means our cleanup
+    // useEffect hasn't been executed yet
+    entitiesToStop = entitiesToStop.some(
+      entity => entity.status === EntityStatus.Stopped
+    )
+      ? entitiesToStop.filter(entity => entity.status !== EntityStatus.Stopped)
+      : entitiesToStop;
+
     const nextEffectEntities: Array<EffectEntity<TState, TEvent>> = [];
     const nextEntitiesToStop: Array<EffectEntity<TState, TEvent>> = [];
 
     if (event.type === flushEffectsSymbol) {
       // Record that effects have already been executed
-      return [state, stateEffectTuples.slice(event.count), nextEntitiesToStop];
+      return [state, stateEffectTuples.slice(event.count), entitiesToStop];
     }
 
     const exec = (

--- a/test/useEffectReducer.test.tsx
+++ b/test/useEffectReducer.test.tsx
@@ -507,9 +507,13 @@ describe('useEffectReducer', () => {
     const helloButton = getByTestId('send-hello');
     const goodbyeButton = getByTestId('send-goodbye');
 
+    // Click each button twice to make sure no effect cleanup
+    // is skipped due to batching
+    fireEvent.click(helloButton);
     fireEvent.click(helloButton);
 
     setTimeout(() => {
+      fireEvent.click(goodbyeButton);
       fireEvent.click(goodbyeButton);
     }, 30);
 


### PR DESCRIPTION
Noticed this issue happen in a real app scenario.

Sometimes, dispatching `flushEffectsSymbol` causes `entitiesToStop` to be cleared out from the state, without the cleanup ever happening.

This was puzzling me at first, because you'd think that if there were any `entitiesToStop`, then they would be stopped before the `flushEffectsSymbol` ever gets a chance to be dispatched. But without this patch, calling `fireEvent.click(goodbyeButton);` twice right after another causes 2 "goodbye" messages to be logged instead of just the one.

In particular, I think what's going on is that when the 2nd goodbye click happens, react batches the dispatch `START` and dispatch `flushEffectsSymbol` together before executing the cleanup effect. The sequence is the following:

```
> Click 1

Dispatch: START
Reducer: Queues up the timeout effect

> Click 2

Dispatch: START (but this time effects need to be flushed before running the reducer!)
Effect: Runs cleanup useEffect with { entitiesToStop: [] }
Effect: Runs execution useEffect that also dispatches flushEffectsSymbol
Reducer: Queues up the new timeout effect
Reducer: Handles flushEffectsSymbol wiping the entitiesToStop (!)

Effect: Runs cleanup useEffect with { entitiesToStop: [] }
Effect: Runs execution useEffect that also dispatches flushEffectsSymbol
Reducer: Handles flushEffectsSymbol

Effect: Runs cleanup useEffect with { entitiesToStop: [] }
Effect: Runs execution useEffect that also dispatches flushEffectsSymbol

Nothing new is dispatched this time around, we've settled
```

The fix makes sure we never lose any `entitiesToStop`, and that we do clear them from the state when they have actually been stopped.